### PR TITLE
Allows empty interface as value field

### DIFF
--- a/xml/xml2rpc.go
+++ b/xml/xml2rpc.go
@@ -138,6 +138,10 @@ func value2Field(value value, field *reflect.Value) error {
 			// methods in lowercase, which cannot be used
 			field_name := uppercaseFirst(s[i].Name)
 			f := field.FieldByName(field_name)
+			emptyValue := reflect.Value{}
+			if f == emptyValue {
+				f = field.FieldByName("N" + field_name)
+			}
 			err = value2Field(s[i].Value, &f)
 		}
 	case len(value.Array) != 0:

--- a/xml/xml2rpc.go
+++ b/xml/xml2rpc.go
@@ -161,7 +161,9 @@ func value2Field(value value, field *reflect.Value) error {
 	}
 
 	if val != nil {
-		if reflect.TypeOf(val) != reflect.TypeOf(field.Interface()) {
+		var iface interface{}
+		if reflect.TypeOf(field.Interface()) != reflect.TypeOf(iface) &&
+			reflect.TypeOf(val) != reflect.TypeOf(field.Interface()) {
 			fault := FaultInvalidParams
 			fault.String += fmt.Sprintf(": fields type mismatch: %s != %s",
 				reflect.TypeOf(val),


### PR DESCRIPTION
Decoding a response using a reply struct with an empty interface field, generates an error like this:

`Invalid Method Parameters: fields type mismatch: int != %!s(<nil>)`

This patch fixes this particular case.

To show a possible use case, a simple modification to server example should be:

```
func (h *HelloService) Say(r *http.Request, args *struct{Who string}, reply *struct{Message []interface{}}) error {
  log.Println("Say", args.Who)
  reply.Message = []interface{}{true, "Hello, " + args.Who + "!", 10}
  return nil
}
```

Of course also in the client example the struct declaration has to change in:

```
func XmlRpcCall(method string, args struct{Who string}) (reply struct{Message []interface{}}, err error) {
```

Running the example, the result will be:

`Response: [%!s(bool=true) Hello, User 1! %!s(int=10)]`